### PR TITLE
Add vim cursor color variable support

### DIFF
--- a/style/variables.css
+++ b/style/variables.css
@@ -327,7 +327,9 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-editor-selected-focused-background: var(--ctp-plt-surface2);
   --jp-editor-cursor-color: var(--ctp-plt-rosewater);
 
-  /* Vim block cursor (applies only if vim extension installed) */
+  /* Vim block cursor (applies only if vim extension installed)
+  https://github.com/jupyterlab-contrib/jupyterlab-vim
+  */
   --jp-vim-cursor-color: var(--ctp-plt-rosewater);
 
   /* Code mirror specific styles */

--- a/style/variables.css
+++ b/style/variables.css
@@ -328,7 +328,7 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-editor-cursor-color: var(--ctp-plt-rosewater);
 
   /* Vim block cursor (applies only if vim extension installed) */
-  --jp-vim-cursor-color: var(--ctp-plt-rosewater) !important;
+  --jp-vim-cursor-color: var(--ctp-plt-rosewater);
 
   /* Code mirror specific styles */
 

--- a/style/variables.css
+++ b/style/variables.css
@@ -327,6 +327,9 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-editor-selected-focused-background: var(--ctp-plt-surface2);
   --jp-editor-cursor-color: var(--ctp-plt-rosewater);
 
+  /* Vim block cursor (applies only if vim extension installed) */
+  --jp-vim-cursor-color: var(--ctp-plt-rosewater) !important;
+
   /* Code mirror specific styles */
 
   --jp-mirror-editor-keyword-color: var(--ctp-plt-red);


### PR DESCRIPTION
As discussed in https://github.com/catppuccin/jupyterlab/issues/9. The vim extension allows `--jp-vim-cursor-color` to style the block cursor for vim normal mode. This PR styles that consistently with the normal line cursor that is colored by `--jp-editor-cursor-color` and which this theme already styles.

The `!important` is required because the vim extension also sets this variable to a default, so this ensures the theme's value overrides it. I've also verified that overrides in  `~/.jupyter/custom/custom.css` do correctly override this value, provided they have `!important`. Important was needed to override the vim extension setting in custom.css anyway, so this is not a change in behavior.