### PR TITLE
Add conda install instruction to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 
 ## Usage
 
-1. Install the JupyterLab extension: `pip install catppuccin-jupyterlab`.
+1. Install the JupyterLab extension: `pip install catppuccin-jupyterlab` or `conda install -c conda-forge catppuccin-jupyterlab`.
 2. Start/restart JupyterLab (`jupyter lab`). If it is already opened, you can reload it by executing "Reset Application State" in the Command Palette (`Ctrl + Shift + C`).
 3. Go to the `Settings > Theme` menu option and choose the desired flavor.
 


### PR DESCRIPTION
The theme was published on conda-forge, so the theme is available for people using the conda package manager now. This just adds in an extra command next to the pip one for conda users to use instead.